### PR TITLE
[WIP] ja: use docs api server rendering home page.

### DIFF
--- a/en/homepage/backers.md
+++ b/en/homepage/backers.md
@@ -1,0 +1,4 @@
+---
+title: Support the Team
+---
+Nuxt.js is an MIT licensed open source project and completely free to use. However, the amount of effort needed to maintain and develop new features for the project is not sustainable without proper financial backing. Your donations directly support office hours, continued enhancements, and most importantly, great documentation and learning material.

--- a/en/homepage/modes.md
+++ b/en/homepage/modes.md
@@ -1,0 +1,4 @@
+---
+title: Rendering modes
+---
+NO CONTENTS

--- a/en/homepage/modes_server_side_rendering.md
+++ b/en/homepage/modes_server_side_rendering.md
@@ -1,0 +1,9 @@
+---
+title: Server Side Rendered
+content_title: Server Side Rendered (Universal)
+---
+The most popular mode for Nuxt. With SSR, also called "universal" or "isomorphic" mode, a Node.js server
+will be used to deliver HTML based on your Vue components to the client instead of the pure javascript.
+Using SSR will lead to a large SEO boost, better UX and more opportunities (compared to a traditional Vue SPA).<br><br>
+Because implementing SSR on your own can be really tedious, Nuxt.js gives you full support out of the box
+and will take care of common pitfalls.

--- a/en/homepage/modes_single_page_app.md
+++ b/en/homepage/modes_single_page_app.md
@@ -1,0 +1,9 @@
+---
+title: Single Page App
+content_title: Single Page Application (SPA)
+---
+Don't need SSR or Static Site Generation but still want to profit from the benefits that Nuxt provides?
+Are you slowly transitioning your app and want to start lightweight? Then the traditional SPA mode will
+likely be your choice.
+The outcome will be a typical Vue SPA as you know it but influenced by your Nuxt configuration and the
+framework itself.

--- a/en/homepage/modes_statically_generated.md
+++ b/en/homepage/modes_statically_generated.md
@@ -1,0 +1,10 @@
+---
+title: Statically Generated
+content_title: Statically Generated (Pre-Rendering)
+---              
+Static Site Generation is a very hot topic right now! Instead of switching to another framework and
+spending time to get used to it, why not killing two birds with one stone?
+<span style="color: #777">(only proverbial 🐦🐦)</span><br><br>
+Nuxt.js supports generating a static website based on your Vue application. It is the "best of both worlds"
+as you don't need a server but still have SEO benefits because Nuxt will pre-render all pages and include
+the necessary HTML. Also, you can deploy the resulting page easily to Netlify or GitHub pages.

--- a/en/homepage/welcome.md
+++ b/en/homepage/welcome.md
@@ -1,0 +1,4 @@
+---
+title: The <span class="nWelcome_Content_Title_Primary">Vue.js</span> Framework
+---
+Nuxt.js presets all the configuration needed to make your development of a Vue.js application enjoyable.

--- a/en/homepage/welcome_figure.md
+++ b/en/homepage/welcome_figure.md
@@ -1,0 +1,4 @@
+---
+title: Welcome figure - video
+---
+Video produced by <a href="https://www.vuemastery.com" target="_blank" rel="noopener">Vue Mastery</a>, download their free <a href="https://www.vuemastery.com/nuxt-cheat-sheet/" target="_blank" rel="noopener">Nuxt Cheat Sheet</a>.

--- a/en/homepage/why.md
+++ b/en/homepage/why.md
@@ -1,0 +1,3 @@
+---
+title: Why Nuxt?
+---

--- a/en/homepage/why_enjoyable.md
+++ b/en/homepage/why_enjoyable.md
@@ -1,0 +1,6 @@
+---
+title: Enjoyable
+---
+Our main focus is the Developer Experience. We love Nuxt.js and continuously improve the framework so you love it too! 💚
+
+Expect appealing solutions, descriptive error messages, powerful defaults and a detailed documentation. If questions or problems come up, our helpful community will help you out.

--- a/en/homepage/why_modular.md
+++ b/en/homepage/why_modular.md
@@ -1,0 +1,4 @@
+---
+title: Modular
+---
+Nuxt is based on a powerful modular architecture. You can choose from more than 50 modules to make your development faster and easier. You don't have to reinvent the wheel to get PWA benefits, add Google Analytics to your page or generate a sitemap.

--- a/en/homepage/why_performant.md
+++ b/en/homepage/why_performant.md
@@ -1,0 +1,6 @@
+---
+title: Performant
+---
+With Nuxt.js, your application will be optimized out of the box.
+We do our best to build performant applications by utilizing Vue.js and Node.js best practices.
+To squeeze every unnecessary bit out of your app Nuxt includes a bundle analyzer and lots of opportunities to fine-tune your app.


### PR DESCRIPTION
See: [need link](need link).

The nuxtjs.org homepage(top page) contents are written in source code directly. To translate it, we need to move these contents to the language resources and docs contents files.

In this pull request, move nuxtjs.org homepage contents to this repository, `*(lang)/homepage/*.md`, and add `/homepage` api to return these.

I'm sending pull request about language resource file here: [need link](need link).

This pull request includes
- `/homepage` and `/homepage/(lang)` api for the nuxtjs.org homepage rendering
- Fallback function for missing language contents, `/homepage` only
  - Add `defaultLang` const for this
- Imported homepage data to `en/homepage/*.md`
  - Partial renderer setting for reproducing original contents
  - The file format is the same as other documents
  - But, "Rendering modes" document files have `content_title` for each content display

I need feedback:
1. There is api that returns document files. But, the homepage has various contents, and if we use it, it requires over ten api request to render at once. Therefore, I'd added new api `/homepage`. Is this a right way? If there is another way, please inform me.